### PR TITLE
Enhance slugify function for Turkish characters

### DIFF
--- a/src/lib/product-loader.ts
+++ b/src/lib/product-loader.ts
@@ -24,9 +24,23 @@ const exportZipFiles = import.meta.glob('/product-plan.zip', {
 /**
  * Slugify a string for use as an ID
  * Converts " & " to "-and-" to maintain semantic meaning
+ * Handles Turkish characters properly
  */
 function slugify(str: string): string {
+  // Turkish character mappings
+  const turkishMap: Record<string, string> = {
+    'ı': 'i', 'İ': 'i', 'i': 'i', 'I': 'i',
+    'ş': 's', 'Ş': 's',
+    'ğ': 'g', 'Ğ': 'g',
+    'ü': 'u', 'Ü': 'u',
+    'ö': 'o', 'Ö': 'o',
+    'ç': 'c', 'Ç': 'c',
+  }
+
   return str
+    .split('')
+    .map(char => turkishMap[char] || char)
+    .join('')
     .toLowerCase()
     .replace(/\s+&\s+/g, '-and-') // Convert " & " to "-and-" first
     .replace(/[^a-z0-9]+/g, '-')


### PR DESCRIPTION
Added Turkish character mappings to the slugify function to handle Turkish characters properly.

## Summary
Updated the slugify function to provide robust support for Turkish localization. This change introduces a character mapping layer that transforms Turkish-specific characters (like ğ, ş, ı) into their ASCII equivalents before the regex cleanup. It also ensures that the " & " symbol is semantically preserved as "-and-" instead of being stripped out.

## Checklist
- [X] Documented steps to test (below)
- [X] Drafted “how to use” docs (if this adds new behavior)
- [X] Backwards compatibility considered (notes if applicable)

## Documented steps to test
1. Test Turkish Mapping: Call slugify("Eskişehir & İstanbul").
> Expected Result: "eskisehir-and-istanbul"

2. Test Semantic Preservation: Call slugify("Bread & Butter").
> Expected Result: "bread-and-butter"
3. Test Casing and Symbols: Call slugify("Ilık Bir Gün @2024!").
> Expected Result: "ilik-bir-gun-2024" (Ensures the dotless 'I' maps to 'i' and non-alphanumerics are cleaned).
4. Test Edge Trimming: Call slugify("---test---").
> Expected Result: "test"

## Notes for reviewers
1. Character Map: Uses a Record<string, string> to explicitly handle ı/İ, ş/Ş, ğ/Ğ, ü/Ü, ö/Ö, and ç/Ç.
2. Pipeline Order: * Maps Turkish characters first.
    - Converts to lowercase.
    - Converts & to -and-.
    - Strips remaining non-alphanumeric characters.
    - Trims leading/trailing hyphens.
