### PR TITLE
fix: normalize CRLF line endings in markdown parsers for Windows compatibility

### DIFF
--- a/src/lib/product-loader.ts
+++ b/src/lib/product-loader.ts
@@ -55,16 +55,19 @@ export function parseProductOverview(md: string): ProductOverview | null {
   if (!md || !md.trim()) return null
 
   try {
+    // Normalize line endings (Windows CRLF → LF)
+    const normalizedMd = md.replace(/\r\n/g, '\n')
+
     // Extract product name from first # heading
-    const nameMatch = md.match(/^#\s+(.+)$/m)
+    const nameMatch = normalizedMd.match(/^#\s+(.+)$/m)
     const name = nameMatch?.[1]?.trim() || 'Product Overview'
 
     // Extract description - content between ## Description and next ##
-    const descMatch = md.match(/## Description\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
+    const descMatch = normalizedMd.match(/## Description\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
     const description = descMatch?.[1]?.trim() || ''
 
     // Extract problems - ### Problem N: Title pattern
-    const problemsSection = md.match(/## Problems & Solutions\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
+    const problemsSection = normalizedMd.match(/## Problems & Solutions\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
     const problems: Problem[] = []
 
     if (problemsSection?.[1]) {
@@ -78,7 +81,7 @@ export function parseProductOverview(md: string): ProductOverview | null {
     }
 
     // Extract features - bullet list after ## Key Features
-    const featuresSection = md.match(/## Key Features\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
+    const featuresSection = normalizedMd.match(/## Key Features\s*\n+([\s\S]*?)(?=\n## |\n#[^#]|$)/)
     const features: string[] = []
 
     if (featuresSection?.[1]) {
@@ -122,8 +125,11 @@ export function parseProductRoadmap(md: string): ProductRoadmap | null {
   try {
     const sections: Section[] = []
 
+    // Normalize line endings (Windows CRLF → LF)
+    const normalizedMd = md.replace(/\r\n/g, '\n')
+
     // Match sections with pattern ### N. Title
-    const sectionMatches = [...md.matchAll(/### (\d+)\.\s*(.+)\n+([\s\S]*?)(?=\n### |\n## |\n#[^#]|$)/g)]
+    const sectionMatches = [...normalizedMd.matchAll(/### (\d+)\.\s*(.+)\n+([\s\S]*?)(?=\n### |\n## |\n#[^#]|$)/g)]
 
     for (const match of sectionMatches) {
       const order = parseInt(match[1], 10)


### PR DESCRIPTION
## Summary
Markdown files created on Windows use CRLF (\\r\\n) line endings, which caused the regex patterns in parseProductOverview and parseProductRoadmap to fail matching section headers.

This fix normalizes line endings to LF (\\n) before parsing, ensuring cross-platform compatibility.

## Problem
Using Cursor on Windows, markdown files (`product-overview.md`, `product-roadmap.md`) are saved with CRLF (`\r\n`) line endings. The regex patterns in `parseProductOverview` and `parseProductRoadmap` use `\n` to match newlines, causing the patterns to fail on Windows systems.

This results in the Sections page showing "No roadmap defined yet" even when `product-roadmap.md` exists and is properly formatted.

## Solution

Added line ending normalization (`md.replace(/\r\n/g, '\n')`) at the start of both parser functions before regex matching. This ensures cross-platform compatibility without changing the regex patterns.

## Documented steps to test
1. Create a new Design OS project (in Cursor?) on Windows
2. Run `/product-vision` to create `product/product-overview.md`
3. Run `/product-roadmap` to create `product/product-roadmap.md` with 3+ sections
4. Verify files have CRLF line endings: `git ls-files --eol | grep product`
5. Start the dev server: `npm run dev`
6. Navigate to the Sections page (`/sections`)
7. Verify all roadmap sections display correctly (not "No roadmap defined yet")
8. Both parsers now correctly parse files regardless of line ending format

## Notes for reviewers
(Sorry for not opening a discussion, just wanted to quickly pass along the fix I used to get past my issue)
