### PR TITLE
Fix slugify for accented characters and apostrophes

### DIFF
--- a/src/lib/product-loader.ts
+++ b/src/lib/product-loader.ts
@@ -27,8 +27,11 @@ const exportZipFiles = import.meta.glob('/product-plan.zip', {
  */
 function slugify(str: string): string {
   return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // Remove diacritics (é→e, ü→u, etc.)
     .toLowerCase()
     .replace(/\s+&\s+/g, '-and-') // Convert " & " to "-and-" first
+    .replace(/['']/g, '')          // Remove apostrophes without inserting hyphens
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '')
 }


### PR DESCRIPTION
## Summary
- Normalize Unicode (NFD) and strip diacritics so accented characters map to their ASCII equivalents (`é`→`e`, `ü`→`u`)
- Remove apostrophes (straight and typographic) without inserting hyphens (`d'accueil`→`daccueil`)

This fixes section ID matching for non-English titles (French, Spanish, German, etc.).

## Test plan
- Verify `"Page d'accueil"` slugifies to `page-daccueil`
- Verify `"Fonctionnalités"` slugifies to `fonctionnalites`
- Verify `"Témoignages"` slugifies to `temoignages`
- Verify existing ASCII-only titles are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)