### PR TITLE
feat: Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye
 
-RUN npx playwright install chromium --with-deps
+RUN npx playwright install --with-deps chromium
+RUN su node -c "curl -fsSL https://claude.ai/install.sh | bash"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye
+
+RUN npx playwright install chromium --with-deps

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,51 @@
+# Development Container
+
+This project includes a development container configuration for consistent development environments across different machines.
+
+## Prerequisites
+
+- Docker
+- A devcontainer-compatible tool (VS Code Dev Containers, GitHub Codespaces, crib, etc.)
+
+## What's Included
+
+- Node.js 20 with TypeScript support
+- Git
+- Playwright (chromium) with browser dependencies pre-installed
+- npm packages from `package.json` auto-installed on container creation
+
+## Getting Started
+
+### VS Code
+
+1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+2. Open the project folder
+3. Click the remote indicator (bottom left corner)
+4. Select "Reopen in Container"
+
+The container will build and initialize automatically (first build takes ~2-3 minutes).
+
+### Other Tools
+
+Use your devcontainer-compatible tool to open this project. Refer to its documentation for specific instructions.
+
+## Available Commands
+
+Once the container is running:
+
+```bash
+npm run dev       # Start Vite dev server (http://localhost:3000)
+npm run build     # Build for production
+npm run lint      # Run ESLint
+npm run preview   # Preview production build
+```
+
+## Playwright MCP Integration
+
+Playwright (chromium) is pre-installed in the container image. To use it with Claude Code's Playwright MCP integration, run this **inside the container**:
+
+```bash
+claude mcp add playwright -- npx @playwright/mcp@latest --headless
+```
+
+**NOTE**: The `--headless` flag is required inside the container since there is no display server.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,12 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  "remoteUser": "node",
+  "containerEnv": {
+    "VITE_HOST": "::"
+  },
   "postCreateCommand": "npm install",
+  "appPort": [3000],
   "forwardPorts": [3000],
   "portsAttributes": {
     "3000": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "design-os",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "npm install",
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Vite Dev Server",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    host: process.env.VITE_HOST || 'localhost',
   },
 })


### PR DESCRIPTION
## Summary
Add devcontainer configuration for containerized development. Pre-installs Playwright chromium) and Claude Code in the image. Only change to existing code is making Vite's server host configurable via `VITE_HOST` env var (defaults to `localhost`, no behavior change outside the container).


## Checklist
- [ ] Linked to related Issue/Discussion
- [x] Documented steps to test (below)
- [x] Drafted "how to use" docs (if this adds new behavior)
- [x] Backwards compatibility considered (notes if applicable)

## Documented steps to test

1. Open the project in a devcontainer-compatible tool (VS Code Dev Containers, GitHub Codespaces, crib, etc.)
2. Verify `npm run dev` serves on port 3000 and is accessible from the host
3. Verify `claude` CLI is available in the container
4. Verify `npx playwright install --dry-run` shows chromium already installed

## Notes for reviewers

- The only change outside `.devcontainer/` is in `vite.config.ts` (env-based host config, defaults to `localhost`)
- Container runs as `node` user, not root
- Port 3000 is published via both `appPort` (Docker-level) and `forwardPorts` (VS Code/Codespaces)