### PR TITLE
fix(shape-section): Section title with '&' generate unrecongized folder.  Explicitly document the " & " → "-and-" conversion in the section-id instructions.

### DIFF
--- a/.claude/commands/design-os/shape-section.md
+++ b/.claude/commands/design-os/shape-section.md
@@ -97,7 +97,7 @@ Create the file at `product/sections/[section-id]/spec.md` with this exact forma
 **Important:**
 - Set `shell: true` if the section should display inside the app shell (this is the default)
 - Set `shell: false` if the section should display as a standalone page without the shell
-- The section-id is the slug version of the section title (lowercase, hyphens instead of spaces)
+- The section-id is the slug version of the section title: lowercase, spaces → hyphens, and **` & ` → `-and-`** (e.g. "Composants & UI" → `composants-and-ui`). This must match exactly what the app's `slugify()` function produces.
 - Don't add features that weren't discussed. Don't leave out features that were discussed.
 
 ### 6b: Generate Sample Data and Types


### PR DESCRIPTION
## Summary            
  The `shape-section` command prompt described section-id slugging as "lowercase, hyphens instead of spaces" — omitting the `" & " → "-and-"` conversion that `slugify()` already applies. As a result, the AI creates folders like `composants-ui` instead of `composants-and-ui`, breaking section
  resolution at runtime.                      
                                          
  Fix: document the `&` rule explicitly in the section-id note, with a concrete example tied to `slugify()`.
                                                                                                                                                                                                                                                                                                            
  ## Linked item
  - Implements: <!-- lien vers la discussion si elle existe -->                                                                                                                                                                                                                                             
                                                            
  ## Checklist                                                                                                                                                                                                                                                                                              
  - [ ] Linked to related Issue/Discussion                  
  - [x] Documented steps to test (below)                                                                                                                                                                                                                                                                    
  - [ ] Drafted "how to use" docs (if this adds new behavior)
  - [x] Backwards compatibility considered (notes if applicable)                                                                                                                                                                                                                                            
                                                            
  ## Documented steps to test                                                                                                                                                                                                                                                                               
  1. Run `/shape-section` on a section whose title contains ` & ` (e.g. "Composants & UI")
  2. Verify the generated folder is `product/sections/composants-and-ui/` (not `composants-ui/`)                                                                                                                                                                                                            
  3. Open the app and confirm the section page resolves correctly at `/sections/composants-and-ui`
                                              
  ## Notes for reviewers                                                                                                                                                                                                                                                                                    
  Prompt-only change, no app code touched. The app-side fix (`slugify` handling `&`) was already merged in 5f773b4 — this closes the gap on the prompt side.   